### PR TITLE
Add controller version select to standard and advanced modes

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.1.7
+VERSION ?= 1.2.0
 
 build:
 	sed -i'' -e 's+version = ".*"+version = "${VERSION}"+g' sst-frontend/src/components/app-bar/index.tsx

--- a/sandbox-starter/controller/controller_init.py
+++ b/sandbox-starter/controller/controller_init.py
@@ -55,7 +55,7 @@ def set_controller_password(ctrl_url, private_ip, cid, password, email):
 
 # Controller initialization
 
-def onboard_controller(ctrl_url, account_id, cid, email, password):
+def onboard_controller(ctrl_url, account_id, cid, email, password, version):
 
     # Set email:
 
@@ -99,7 +99,7 @@ def onboard_controller(ctrl_url, account_id, cid, email, password):
 
 # Upgrade Controller
     print("Upgrading controller. It can take several minutes", flush=True)
-    upgrade = {'action': 'upgrade', 'CID': cid, 'version': '6.6'}
+    upgrade = {'action': 'upgrade', 'CID': cid, 'version': version}
     print("Upgrading to latest release", flush=True)
     try:
         upgrade_latest = requests.request(
@@ -189,6 +189,7 @@ def main():
     email = os.environ['AVIATRIX_EMAIL']
     # password = getpass.getpass("Enter new password: ")
     password = os.environ['AVIATRIX_PASSWORD']
+    version = os.environ['CONTROLLER_VERSION']
     ctrl_url = 'https://'+str(public_ip)+str("/v1/api")
 
     try:
@@ -207,7 +208,7 @@ def main():
         sys.exit(1)
 
     onboard_controller(ctrl_url=ctrl_url,
-                       account_id=account_id, cid=cid, email=email, password=password)
+                       account_id=account_id, cid=cid, email=email, password=password, version=version)
 
     time.sleep(150)
 

--- a/sst-backend/utils/process_utils.py
+++ b/sst-backend/utils/process_utils.py
@@ -24,25 +24,25 @@ def proccess_file(command):
 
 
 def controller_file_change(data):
-    """controller variable change in this fucntion"""
+    """controller variable change in this function"""
     region = data.get('region')
     az = data.get('az')
     vpc_cidr = data.get('vpc_cidr')
     vpc_subnet = data.get('vpc_subnet')
+    controller_version = data.get('controller_version')
     controller_license_type = data.get('controller_license_type')
     if not controller_license_type:
         controller_license_type = "meteredplatinum"
     if region and az and vpc_cidr and vpc_subnet and controller_license_type:
 
         command = ['bash', '-c', '. /root/sandbox_starter_web.sh;'
-                                    ' controller_file_change "' + region + '" "'
-                    + az + '" "' + vpc_cidr + '" "' + vpc_subnet + '" "' + controller_license_type + '"']
-    else:        
+                   ' controller_file_change "' + region + '" "'
+                   + az + '" "' + vpc_cidr + '" "' + vpc_subnet + '" "' + controller_version + '" "' + controller_license_type + '"']
+    else:
         command = ['bash', '-c', '. /root/sandbox_starter_web.sh;'
-                                ' controller_file_change_std "' + controller_license_type + '"']
+                   ' controller_file_change_std "' + controller_version + '" "' + controller_license_type + '"']
 
     proccess_file(command)
-
 
 
 def mcna_file_change_aws(data):

--- a/sst-backend/utils/processes.py
+++ b/sst-backend/utils/processes.py
@@ -191,6 +191,7 @@ def launch_controller(controller_data):
     recovery_email = controller_data.get('recovery_email')
     password = controller_data.get('password')
     confirm_password = controller_data.get('confirm_password')
+    controller_version = controller_data.get('controller_version')
     controller_license_type = controller_data.get('controller_license_type')
     if not controller_license_type:
         controller_license_type = "meteredplatinum"
@@ -201,7 +202,8 @@ def launch_controller(controller_data):
     controller = {
         'email': email,
         'recovery_email': recovery_email,
-        'controller_license_type': controller_license_type
+        'controller_license_type': controller_license_type,
+        'controller_version': controller_version
     }
 
     data['processedData'].update({'controller': controller})
@@ -212,7 +214,7 @@ def launch_controller(controller_data):
     command = ['bash', '-c', '. /root/sandbox_starter_web.sh;'
                              ' launch_controller '
                + email + ' ' + recovery_email + ' '
-               + password + ' ' + controller_license]
+               + password + ' ' + controller_version + ' ' + controller_license]
     state = 2
     stateName = 'launchController'
     proccess(command, state, stateName)

--- a/sst-frontend/src/components/app-bar/index.tsx
+++ b/sst-frontend/src/components/app-bar/index.tsx
@@ -9,7 +9,7 @@ import { helpIcon, reloadIcon } from "svgs";
 import { AppState } from "store";
 
 export default function AppBar() {
-  const version = "1.1.7";
+  const version = "1.2.0";
   const dispatch = useDispatch();
   const history = useHistory();
   const { is_advance } = useSelector<AppState, AppState["configuration"]>(

--- a/sst-frontend/src/components/app-bar/index.tsx-e
+++ b/sst-frontend/src/components/app-bar/index.tsx-e
@@ -9,7 +9,7 @@ import { helpIcon, reloadIcon } from "svgs";
 import { AppState } from "store";
 
 export default function AppBar() {
-  const version = "1.1.7";
+  const version = "1.2.0";
   const dispatch = useDispatch();
   const history = useHistory();
   const { is_advance } = useSelector<AppState, AppState["configuration"]>(

--- a/sst-frontend/src/pages/configuration/steps/launch-controller/advance-form.tsx
+++ b/sst-frontend/src/pages/configuration/steps/launch-controller/advance-form.tsx
@@ -53,6 +53,7 @@ export default function AdvanceForm(props: ComponentProps) {
       region: step2_variables?.region || "",
       vpc_cidr: step2_variables?.vpc_cidr || "",
       vpc_subnet: step2_variables?.vpc_subnet || "",
+      controller_version: step2_variables?.controller_version || "",
       controller_license_type: step2_variables?.controller_license_type || "",
       controller_license: step2_variables?.controller_license || "",
     }
@@ -62,6 +63,7 @@ export default function AdvanceForm(props: ComponentProps) {
       region: step2_variables?.region || "",
       vpc_cidr: step2_variables?.vpc_cidr || "",
       vpc_subnet: step2_variables?.vpc_subnet || "",
+      controller_version: step2_variables?.controller_version || "",
       controller_license_type: step2_variables?.controller_license_type || "",
       controller_license: step2_variables?.controller_license || "",
     };
@@ -76,6 +78,7 @@ export default function AdvanceForm(props: ComponentProps) {
         email: "",
         password: "",
         confirm_password: "",
+        controller_version: "6.6",
         controller_license_type: "meteredplatinum",
         controller_license: "",
         az: "us-east-1a",
@@ -209,6 +212,53 @@ export default function AdvanceForm(props: ComponentProps) {
               disabled={pageDisabled}
             />{" "}
             <Separator />
+            <FormControl
+              variant="outlined"
+              size="medium"
+              style={{ width: 360 }}
+            >
+              <InputLabel
+                variant="outlined"
+                style={{
+                  fontSize: 14,
+                }}
+                htmlFor="controller_version"
+              >
+                Controller Version
+              </InputLabel>
+              <Select
+                labelId="controller_version"
+                name="controller_version"
+                value={values.controller_version}
+                onChange={handleChange}
+                label="Controller Version"
+                variant="outlined"
+                style={{
+                  color: "black",
+                  fontSize: 14,
+                }}
+                disabled={pageDisabled}
+              >
+                <MenuItem value="6.6">6.6</MenuItem>
+                <MenuItem value="6.7">6.7</MenuItem>
+              </Select>
+            </FormControl>
+            {(() => {
+              if (values.controller_version === "6.7") {
+                return (
+                  <>
+                    <Paragraph
+                      customClasses="--light"
+                      text={
+                        <span>
+                          If using the SST as a prerequisite to ACE IaC, please select Controller Version 6.6
+                        </span>
+                      }
+                    ></Paragraph>
+                  </>
+                );
+              }
+            })()}
             <FormControl
               variant="outlined"
               size="medium"

--- a/sst-frontend/src/pages/configuration/steps/launch-controller/standard-form.tsx
+++ b/sst-frontend/src/pages/configuration/steps/launch-controller/standard-form.tsx
@@ -29,6 +29,7 @@ export default function StandardForm(props: ComponentProps) {
             recovery_email: values.email,
             password: values.password,
             confirm_password: values.confirm_password,
+            controller_version: values.controller_version,
             controller_license_type: values.controller_license_type,
             controller_license: values.controller_license,
           },
@@ -44,6 +45,7 @@ export default function StandardForm(props: ComponentProps) {
       email: controller.email,
       password: controller.password,
       confirm_password: controller.confirm_password,
+      controller_version: controller.controller_version,
       controller_license_type: controller.controller_license_type,
       controller_license: controller.controller_license,
     }
@@ -54,6 +56,7 @@ export default function StandardForm(props: ComponentProps) {
         email: "",
         password: "",
         confirm_password: "",
+        controller_version: "6.6",
         controller_license_type: "meteredplatinum",
         controller_license: "",
       }}
@@ -127,6 +130,49 @@ export default function StandardForm(props: ComponentProps) {
             helperText={errors.confirm_password}
             disabled={pageDisabled}
           />
+          <FormControl variant="outlined" size="medium" style={{ width: 360 }}>
+            <InputLabel
+              style={{
+                fontSize: 14,
+              }}
+              variant="outlined"
+              htmlFor="controller_version"
+            >
+              Controller Version
+            </InputLabel>
+            <Select
+              labelId="controller_version"
+              name="controller_version"
+              value={values.controller_version}
+              onChange={handleChange}
+              label="Controller Version"
+              variant="outlined"
+              style={{
+                color: "black",
+                fontSize: 14,
+              }}
+              disabled={pageDisabled}
+            >
+              <MenuItem value="6.6">6.6</MenuItem>
+              <MenuItem value="6.7">6.7</MenuItem>
+            </Select>
+          </FormControl>
+          {(() => {
+            if (values.controller_version === "6.7") {
+              return (
+                <>
+                  <Paragraph
+                    customClasses="--light"
+                    text={
+                      <span>
+                        If using the SST as a prerequisite to ACE IaC, please select Controller Version 6.6
+                      </span>
+                    }
+                  ></Paragraph>
+                </>
+              );
+            }
+          })()}
           <FormControl variant="outlined" size="medium" style={{ width: 360 }}>
             <InputLabel
               style={{

--- a/sst-frontend/src/types/api.ts
+++ b/sst-frontend/src/types/api.ts
@@ -47,6 +47,7 @@ export type GetStepResponse = {
         email: string;
         password: string;
         recovery_email: string;
+        controller_version: string;
         controller_license_type: string;
         controller_license: string;
       };
@@ -82,6 +83,7 @@ export type Step2Variables = {
     az: string;
     vpc_cidr: string;
     vpc_subnet: string;
+    controller_version: string;
     controller_license_type: string;
     controller_license: string;
   };
@@ -125,6 +127,7 @@ export type ControllerPayload = {
   recovery_email: string;
   password: string;
   confirm_password: string;
+  controller_version: string;
   controller_license_type: string;
   controller_license?: string;
 };

--- a/sst-frontend/src/utils/constants.ts
+++ b/sst-frontend/src/utils/constants.ts
@@ -36,6 +36,7 @@ export const FORM_CONFIGS = {
       email: "",
       password: "",
       confirm_password: "",
+      controller_version: "",
       controller_license_type: "",
       controller_license: "",
     },
@@ -47,6 +48,7 @@ export const FORM_CONFIGS = {
       az: "",
       vpc_cidr: "",
       vpc_subnet: "",
+      controller_version: "",
       controller_license_type: "",
       controller_license: "",
     },
@@ -62,6 +64,7 @@ export const FORM_CONFIGS = {
           passwordRegex,
           "Must Contain 8 Characters, One Uppercase, One Lowercase, One Number and one special case (@!%*#?) Character"
         ),
+      controller_version: yup.string().oneOf(["6.6", "6.7"]),
       controller_license_type: yup.string().oneOf(["meteredplatinum", "byol"]),
       confirm_password: yup.string().required("Required"),
       controller_license: yup.string().when("controller_license_type", {
@@ -86,6 +89,7 @@ export const FORM_CONFIGS = {
       confirm_password: yup.string().required("Required"),
       region: yup.string().required("Required"),
       az: yup.string().required("Required"),
+      controller_version: yup.string().oneOf(["6.6", "6.7"]),
       controller_license_type: yup.string().oneOf(["meteredplatinum", "byol"]),
       vpc_cidr: yup
         .string()


### PR DESCRIPTION
There is now a version dropdown on step 2 to select which version of the controller to deploy - currently 6.6 or 6.7. This allows for deployment of an ACE-compatible version along with latest if needed.

Also updated the sst [documentation](https://community.aviatrix.com/t/g9hx9jh#launch-the-controller-in-aws) to include a relevant screenshot.