### PR TITLE
Remove copilot icon

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.2.2
+VERSION ?= 1.2.3
 
 build:
 	sed -i'' -e 's+version = ".*"+version = "${VERSION}"+g' sst-frontend/src/components/app-bar/index.tsx

--- a/sst-frontend/src/components/app-bar/index.tsx
+++ b/sst-frontend/src/components/app-bar/index.tsx
@@ -9,7 +9,7 @@ import { helpIcon, reloadIcon } from "svgs";
 import { AppState } from "store";
 
 export default function AppBar() {
-  const version = "1.2.2";
+  const version = "1.2.3";
   const dispatch = useDispatch();
   const history = useHistory();
   const { is_advance } = useSelector<AppState, AppState["configuration"]>(

--- a/sst-frontend/src/svgs/index.tsx
+++ b/sst-frontend/src/svgs/index.tsx
@@ -138,14 +138,6 @@ export const CoverImage = (
           Controller-0
         </tspan>
       </text>
-      <text transform="matrix(1 0 0 1 42.7951 180)" className="st8">
-        <tspan x="0" y="0" className="st1 st6 st9">
-          Aviatrix
-        </tspan>
-        <tspan x="46.6" y="0" className="st5 st6 st9">
-          Copilot
-        </tspan>
-      </text>
       <path
         id="Rectangle_50"
         className="st10"


### PR DESCRIPTION
Removes the copilot icon from the architecture diagram since copilot was removed in v1.2.2 (in favor of the new `Deploy Copilot` workflow in the controller).