### PR TITLE
Increase controller initialization timeout

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.4.0
+VERSION ?= 1.4.1
 
 build:
 	sed -i'' -e 's+version = ".*"+version = "${VERSION}"+g' sst-frontend/src/components/app-bar/index.tsx

--- a/sandbox-starter/controller-govcloud/main.tf
+++ b/sandbox-starter/controller-govcloud/main.tf
@@ -14,7 +14,7 @@ module "aviatrix_controller_aws" {
   incoming_ssl_cidrs          = ["0.0.0.0/0"]
   instance_type               = var.instance_type
   type                        = "BYOL"
-  controller_launch_wait_time = "120"
+  controller_launch_wait_time = "210"
   vpc_cidr                    = var.vpc_cidr
   subnet_cidr                 = var.vpc_subnet
 }

--- a/sandbox-starter/controller/main.tf
+++ b/sandbox-starter/controller/main.tf
@@ -14,7 +14,7 @@ module "aviatrix_controller_aws" {
   incoming_ssl_cidrs          = ["0.0.0.0/0"]
   instance_type               = var.instance_type
   type                        = "BYOL"
-  controller_launch_wait_time = "120"
+  controller_launch_wait_time = "210"
   vpc_cidr                    = var.vpc_cidr
   subnet_cidr                 = var.vpc_subnet
 }

--- a/sst-frontend/src/components/app-bar/index.tsx
+++ b/sst-frontend/src/components/app-bar/index.tsx
@@ -9,7 +9,7 @@ import { helpIcon, reloadIcon } from "svgs";
 import { AppState } from "store";
 
 export default function AppBar() {
-  const version = "1.4.0";
+  const version = "1.4.1";
   const dispatch = useDispatch();
   const history = useHistory();
   const { is_advance } = useSelector<AppState, AppState["configuration"]>(


### PR DESCRIPTION
AMI in some regions is slower to initialize than others. Switch to the engineering default value.